### PR TITLE
changed outputtype to library in core and infastr..

### DIFF
--- a/src/Chirp.Core/Chirp.Core.csproj
+++ b/src/Chirp.Core/Chirp.Core.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <OutputType>Library</OutputType>
     <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/src/Chirp.Core/Program.cs
+++ b/src/Chirp.Core/Program.cs
@@ -1,2 +1,12 @@
-﻿// See https://aka.ms/new-console-template for more information
-Console.WriteLine("Hello, World!");
+﻿using System;
+
+namespace Chirp.Core
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Hello World!");
+        }
+    }
+}

--- a/src/Chirp.Infrastructure/Chirp.Infrastructure.csproj
+++ b/src/Chirp.Infrastructure/Chirp.Infrastructure.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <OutputType>Exe</OutputType>
+    <OutputType>Library</OutputType>
     <TargetFramework>net7.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>

--- a/src/Chirp.Infrastructure/Program.cs
+++ b/src/Chirp.Infrastructure/Program.cs
@@ -1,1 +1,12 @@
-Console.WriteLine("[Infrastructure] Hello, World!");
+using System;
+
+namespace Chirp.Infrastructure
+{
+    class Program
+    {
+        static void Main(string[] args)
+        {
+            Console.WriteLine("Hello World!");
+        }
+    }
+}


### PR DESCRIPTION
The outputtype in our csproj files were "Exe", they had to be Library (.dll): A .dll (Dynamic-Link Library) file is a library that contains code and data that can be used by more than one program at the same time. In the context of .NET, a .dll file can contain multiple compiled classes and methods (including web application controllers, services, etc.) that can be referenced and used by other .NET applications. When you’re building a web application, you’re essentially building a library of classes and methods that the web server can call in response to HTTP requests. (fra gpt)

When changing the outputtype to library from Exe, we also had to update the program.cs files in core and infrastructure. They needed namespace and a class declaration, compared the prior console print statement saying "hello world"